### PR TITLE
Updated poly_to_mask function

### DIFF
--- a/dicom_contour/utils.py
+++ b/dicom_contour/utils.py
@@ -40,7 +40,9 @@ def poly_to_mask(polygon, width, height):
     :param height: scalar image height
     :return: Boolean mask of shape (height, width)
     """
-
+    # Added if statement. Therefore, if a slice has less than three contour points it will be skiped instead of crashing the code. 
+    if len(polygon) > 3:
+        return np.zeros((height,width), dtype = bool)
     # http://stackoverflow.com/a/3732128/1410871
     img = Image.new(mode='L', size=(width, height), color=0)
     ImageDraw.Draw(img).polygon(xy=polygon, outline=0, fill=1)
@@ -82,3 +84,4 @@ def get_roi_names(contour_data):
     """
     roi_seq_names = [roi_seq.ROIName for roi_seq in list(contour_data.StructureSetROISequence)]
     return roi_seq_names
+


### PR DESCRIPTION
Hello Kerem, 
While using your code to convert DICOM images to arrays I was experiencing some issues with regards to some contours. As the delineations within our dataset were done by an oncologist, there were several instances where their would be only one voxel delineated in a slice. Since the poly_to_mask function requires at least 2 voxels to function it would crash the code. Therefore I added an if statement neglecting slices that the polygon is less than three points (used three as that is the minimum number of voxels in a slice to be accepted within treatment planning software for radiation therapy). This was slices with less than 3 points are neglected and you receive the final array of the contour instead of crashing. 
I hope you find these alterations useful and thank you very much for the extensive repository!
Kyriakos Fotiou